### PR TITLE
Allow QuartzAutofacFactoryModule to be registered using RegisterModule<>()

### DIFF
--- a/src/Autofac.Extras.Quartz/QuartzAutofacFactoryModule.cs
+++ b/src/Autofac.Extras.Quartz/QuartzAutofacFactoryModule.cs
@@ -33,11 +33,20 @@ namespace Autofac.Extras.Quartz
         public Action<AutofacSchedulerFactory> ConfigureSchedulerFactory = null;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="QuartzAutofacFactoryModule"/> class with a default lifetime scope name.
+        /// </summary>
+        /// <exception cref="System.ArgumentNullException">lifetimeScopeName</exception>
+        public QuartzAutofacFactoryModule()
+            : this(LifetimeScopeName)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="QuartzAutofacFactoryModule"/> class.
         /// </summary>
         /// <param name="lifetimeScopeName">Name of the lifetime scope to wrap job resolution and execution.</param>
         /// <exception cref="System.ArgumentNullException">lifetimeScopeName</exception>
-        public QuartzAutofacFactoryModule([NotNull] string lifetimeScopeName = LifetimeScopeName)
+        public QuartzAutofacFactoryModule([NotNull] string lifetimeScopeName)
         {
             if (lifetimeScopeName == null) throw new ArgumentNullException("lifetimeScopeName");
             _lifetimeScopeName = lifetimeScopeName;

--- a/src/Tests/QuartzAutofacFactoryModuleTests.cs
+++ b/src/Tests/QuartzAutofacFactoryModuleTests.cs
@@ -51,6 +51,13 @@ namespace Autofac.Extras.Quartz.Tests
             {}
         }
 
+        [Test]
+        public void CanUseGenericAutofacModuleRegistrationSyntax()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterModule<QuartzAutofacFactoryModule>();
+            cb.Build();
+        }
 
         [Test]
         public void ShouldRegisterAutofacSchedulerFactory()


### PR DESCRIPTION
Using a default paramter rather than a method overload means that I cannot write:
builder.RegisterModule<QuartzAutofacFactoryModule>()

This pull request fixes that problem.
