### PR TITLE
Don't wrap exception thrown in IJob.Execute with misleading SchedulerConfigException

### DIFF
--- a/src/Autofac.Extras.Quartz/AutofacJobFactory.cs
+++ b/src/Autofac.Extras.Quartz/AutofacJobFactory.cs
@@ -148,14 +148,18 @@ namespace Autofac.Extras.Quartz
                 var scope = _lifetimeScope.BeginLifetimeScope(_scopeName);
                 try
                 {
-                    RunningJob = CreateJob(scope);
+                    try
+                    {
+                        RunningJob = CreateJob(scope);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new SchedulerConfigException(string.Format(CultureInfo.InvariantCulture,
+                            "Failed to instantiate Job '{0}' of type '{1}'",
+                            _bundle.JobDetail.Key, _bundle.JobDetail.JobType), ex);
+                    }
+
                     RunningJob.Execute(context);
-                }
-                catch (Exception ex)
-                {
-                    throw new SchedulerConfigException(string.Format(CultureInfo.InvariantCulture,
-                        "Failed to instantiate Job '{0}' of type '{1}'",
-                        _bundle.JobDetail.Key, _bundle.JobDetail.JobType), ex);
                 }
                 finally
                 {


### PR DESCRIPTION
This commit fixes a misleading exception when a decorated IJob throws an exception in its Execute method.

Without this change, the error message implies that the exception occurs while instantiating a job. However, if IJob.Execute is invoked then this must not be the case.

Includes test cases to verify correct behavior.