### PR TITLE
Passing the context to the configuration provider

### DIFF
--- a/src/Autofac.Extras.Quartz/QuartzAutofacFactoryModule.cs
+++ b/src/Autofac.Extras.Quartz/QuartzAutofacFactoryModule.cs
@@ -57,7 +57,7 @@ namespace Autofac.Extras.Quartz
         ///     <seealso cref="StdSchedulerFactory" /> for some configuration property names.
         /// </summary>
         [CanBeNull]
-        public Func<NameValueCollection> ConfigurationProvider { get; set; }
+        public Func<IComponentContext, NameValueCollection> ConfigurationProvider { get; set; }
 
         /// <summary>
         ///     Override to add registrations to the container.
@@ -81,7 +81,7 @@ namespace Autofac.Extras.Quartz
                 var cfgProvider = ConfigurationProvider;
 
                 var autofacSchedulerFactory = cfgProvider != null
-                    ? new AutofacSchedulerFactory(cfgProvider(), c.Resolve<AutofacJobFactory>())
+                    ? new AutofacSchedulerFactory(cfgProvider(c), c.Resolve<AutofacJobFactory>())
                     : new AutofacSchedulerFactory(c.Resolve<AutofacJobFactory>());
                 return autofacSchedulerFactory;
             })

--- a/src/Tests/QuartzAutofacFactoryModuleTests.cs
+++ b/src/Tests/QuartzAutofacFactoryModuleTests.cs
@@ -85,7 +85,7 @@ namespace Autofac.Extras.Quartz.Tests
             var customSchedulerName = Guid.NewGuid().ToString();
             configuration[StdSchedulerFactory.PropertySchedulerInstanceName] = customSchedulerName;
 
-            _quartzAutofacFactoryModule.ConfigurationProvider = () => configuration;
+            _quartzAutofacFactoryModule.ConfigurationProvider = context => configuration;
 
             var scheduler = _container.Resolve<IScheduler>();
             scheduler.SchedulerName.Should().BeEquivalentTo(customSchedulerName);


### PR DESCRIPTION
I need access to the context because I register configuration objects with Autofac so I would need the context to resolve those objects.