### PR TITLE
Updated to Autofac 4.0.0-rc3-280 and fixed PropertiesAutowired

### DIFF
--- a/src/Autofac.Extras.Quartz.sln
+++ b/src/Autofac.Extras.Quartz.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{54808FE4-6D0F-402B-BA6F-D65E63C8F3E6}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Autofac.Extras.Quartz.sln
+++ b/src/Autofac.Extras.Quartz.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{54808FE4-6D0F-402B-BA6F-D65E63C8F3E6}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Autofac.Extras.Quartz/Autofac.Extras.Quartz.csproj
+++ b/src/Autofac.Extras.Quartz/Autofac.Extras.Quartz.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac.Extras.Quartz</RootNamespace>
     <AssemblyName>Autofac.Extras.Quartz</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Autofac.Extras.Quartz.XML</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -40,9 +42,9 @@
     <AssemblyOriginatorKeyFile>..\keyfile.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.0.0-rc3-280\lib\net451\Autofac.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>

--- a/src/Autofac.Extras.Quartz/QuartzAutofacJobsModule.cs
+++ b/src/Autofac.Extras.Quartz/QuartzAutofacJobsModule.cs
@@ -11,6 +11,7 @@ namespace Autofac.Extras.Quartz
 {
     using System;
     using System.Reflection;
+    using Core;
     using global::Quartz;
     using JetBrains.Annotations;
     using Module = Autofac.Module;
@@ -65,11 +66,11 @@ namespace Autofac.Extras.Quartz
         protected override void Load(ContainerBuilder builder)
         {
             var registrationBuilder = builder.RegisterAssemblyTypes(_assembliesToScan)
-                .Where(type => !type.IsAbstract && typeof (IJob).IsAssignableFrom(type))
+                .Where(type => !type.IsAbstract && typeof(IJob).IsAssignableFrom(type))
                 .AsSelf().InstancePerLifetimeScope();
 
             if (AutoWireProperties)
-                registrationBuilder.PropertiesAutowired(PropertyWiringOptions);
+                registrationBuilder.PropertiesAutowired(new DefaultPropertySelector(PropertyWiringOptions == PropertyWiringOptions.PreserveSetValues));
         }
     }
 }

--- a/src/Autofac.Extras.Quartz/packages.config
+++ b/src/Autofac.Extras.Quartz/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net40" />
+  <package id="Autofac" version="4.0.0-rc3-280" targetFramework="net451" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net40" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net40" developmentDependency="true" />

--- a/src/Samples/SimpleService/App.config
+++ b/src/Samples/SimpleService/App.config
@@ -8,7 +8,7 @@
 
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
   </startup>
   <common>
     <logging>
@@ -58,7 +58,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Quartz" publicKeyToken="f6b8c98a402cc8a4" culture="neutral" />

--- a/src/Samples/SimpleService/SimpleService.csproj
+++ b/src/Samples/SimpleService/SimpleService.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleService</RootNamespace>
     <AssemblyName>SimpleService</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -34,8 +35,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac">
-      <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.4.0.0-rc3-280\lib\net451\Autofac.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>

--- a/src/Samples/SimpleService/packages.config
+++ b/src/Samples/SimpleService/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net45" />
+  <package id="Autofac" version="4.0.0-rc3-280" targetFramework="net451" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac.Extras.Quartz.Tests</RootNamespace>
     <AssemblyName>Autofac.Extras.Quartz.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -50,9 +50,9 @@
       <HintPath>..\packages\Alphacloud.Common.Testing.Nunit.0.3.3.0\lib\net45\Alphacloud.Common.Testing.Nunit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.0.0-rc3-280\lib\net451\Autofac.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="AutoMapper, Version=4.2.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.4.2.1\lib\net45\AutoMapper.dll</HintPath>
@@ -83,8 +83,8 @@
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.4.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.4.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Quartz">

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="FluentAssertions" version="4.3.2" targetFramework="net45" />
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
-  <package id="NUnit" version="3.2.0" targetFramework="net451" />
-  <package id="NUnit.ConsoleRunner" version="3.2.0" targetFramework="net451" />
+  <package id="NUnit" version="3.4.0" targetFramework="net451" />
+  <package id="NUnit.ConsoleRunner" version="3.4.0" targetFramework="net451" />
   <package id="Quartz" version="2.3.3" targetFramework="net45" />
 </packages>

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Alphacloud.Common.Testing.Nunit" version="0.3.3.0" targetFramework="net45" />
-  <package id="Autofac" version="3.5.2" targetFramework="net45" />
+  <package id="Autofac" version="4.0.0-rc3-280" targetFramework="net451" />
   <package id="AutoMapper" version="4.2.1" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="FluentAssertions" version="4.3.2" targetFramework="net45" />
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
-  <package id="NUnit" version="3.2.0" targetFramework="net45" />
-  <package id="NUnit.ConsoleRunner" version="3.2.0" targetFramework="net45" />
+  <package id="NUnit" version="3.2.0" targetFramework="net451" />
+  <package id="NUnit.ConsoleRunner" version="3.2.0" targetFramework="net451" />
   <package id="Quartz" version="2.3.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes the PropertiesAutowired runtime issue #22 occurring since the latest Autofac 4.0.0-rc3-280 

Had to upgrade to .NET 4.5.1 for Autofac 4.0.