### PR TITLE
Removed unneeded dependency to System.Runtime

### DIFF
--- a/src/Autofac.Extras.Quartz/packages.config
+++ b/src/Autofac.Extras.Quartz/packages.config
@@ -5,5 +5,4 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
   <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net451" developmentDependency="true" />
   <package id="Quartz" version="2.4.1" targetFramework="net451" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This dependency is wrecking havoc with my project when using .NET 4.6.2 on team city.

I am getting errors like:

`CSC error CS1703: Multiple assemblies with equivalent identity have been imported: 'C:\BuildAgent\work\Project\src\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll' and 'C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\Facades\System.Runtime.dll'. Remove one of the duplicate references.`

Turns out this dependency isn't needed for Autofac.Extras.Quartz.