### PR TITLE
Adding the ability to override job resolver method in AutofacJobFactory

### DIFF
--- a/src/Autofac.Extras.Quartz/AutofacJobFactory.cs
+++ b/src/Autofac.Extras.Quartz/AutofacJobFactory.cs
@@ -89,14 +89,14 @@ namespace Autofac.Extras.Quartz
             if (bundle == null) throw new ArgumentNullException(nameof(bundle));
             if (scheduler == null) throw new ArgumentNullException(nameof(scheduler));
 
-            var jobType = bundle.JobDetail.JobType;
-
+            var jobDetail = bundle.JobDetail;
             var nestedScope = _lifetimeScope.BeginLifetimeScope(_scopeTag);
 
             IJob newJob;
             try
             {
-                newJob = (IJob) nestedScope.Resolve(jobType);
+                newJob = ResolveJobInstance(nestedScope, jobDetail);
+
                 var jobTrackingInfo = new JobTrackingInfo(nestedScope);
                 RunningJobs[newJob] = jobTrackingInfo;
                 nestedScope = null;
@@ -109,6 +109,23 @@ namespace Autofac.Extras.Quartz
                     bundle.JobDetail.Key, bundle.JobDetail.JobType), ex);
             }
             return newJob;
+        }
+
+        /// <summary>
+        /// Overridable resolve strategy for IJob instance
+        /// </summary>
+        /// <param name="nestedScope">
+        ///     Nested ILifetimeScope for resolving Job instance with other dependences
+        /// </param>
+        /// <param name="jobDetail">
+        ///     The <see cref="T:Quartz.IJobDetail" />
+        ///     and other info about job
+        /// </param>
+        /// <returns></returns>
+        protected virtual IJob ResolveJobInstance(ILifetimeScope nestedScope, IJobDetail jobDetail)
+        {
+            var jobType = jobDetail.JobType;
+            return  (IJob)nestedScope.Resolve(jobType);
         }
 
         /// <summary>


### PR DESCRIPTION
Hi

I have case, when I need to resolve new Job from AutofacJobFactory with some custom dependences.
Example:

```c#
public virtual IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler)
{
      ...            
      var dependencyName = bundle.JobDetail.JobDataMap.GetString("dependencyName");
      var factory = nestedScope.Resolve<Job.Factory>();
      newJob = factory.Invoke(nestedScope.ResolveNamed<IDependency>(dependencyName));
      ...
      return newJob;
}
```
I explored the AutofacJobFactory and couldn't find a solution to change resolve strategy.
The method `NewJob` is virtual, but `internal class JobTrackingInfo`, property `internal RunningJobs` don't let me override it clear.

I would to propose some changes on the 'AutofacJobFactory' with ability to overide Resolve strategy.
What do you think about it?


P.S. Sorry for multiple pull requests